### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use ~> "2.X.X" for swift 1.2
 Use ~> "3.X.X" for swift 2
 
     pod 'ApiNetWork'
-Cocoapods requires iOS 8.0 or higher.
+CocoaPods requires iOS 8.0 or higher.
 If you're supporting iOS 7, or if you prefer, you can just drop ApiNetWork.swift to your project.
 
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
